### PR TITLE
Cleaned up documentation, fixed some bugs

### DIFF
--- a/src/SD4SOLPS.jl
+++ b/src/SD4SOLPS.jl
@@ -138,7 +138,7 @@ function geqdsk_to_imas(eqdsk_file, dd; time_index=1)
 end
 
 """
-    core_profiles_2d(dd, time_idx, quantity, r, z)
+    core_profile_2d(dd, prof_time_idx, eq_time_idx, quantity, r, z)
 
 Reads a 1D core profile and flux map and returns a quantity at requested R,Z points
 dd: a data dictionary instance with equilibrium and core profile data loaded

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -188,7 +188,7 @@ end
 
 @testset "heavy_utilities" begin
     # Test for finding files in allowed folders
-    sample_path = splitdir(pathof(SOLPS2IMAS))[1] * "/../samples/"
+    sample_path = splitdir(pathof(SOLPS2IMAS))[1] * "/../samples"
     file_list = SD4SOLPS.find_files_in_allowed_folders(
         sample_path; eqdsk_file="thereisntoneyet", allow_reduced_versions=true,
     )
@@ -197,7 +197,7 @@ end
     @test length(b2fgmtry) > 10
     @test endswith(b2fgmtry, "b2fgmtry_red") | endswith(b2fgmtry, "b2fgmtry")
     @test length(b2time) > 10
-    @test endswith(b2time, "b2time_red.nc") | endswith(b2fgmtry, "b2time.nc")
+    @test endswith(b2time, "b2time_red.nc") | endswith(b2time, "b2time.nc")
     @test length(b2mn) > 10
     @test endswith(b2mn, "b2mn.dat")
     @test length(gridspec) > 10
@@ -301,8 +301,8 @@ end
 @testset "preparation" begin
     eqdsk_file = "geqdsk_iter_small_sample"
     sample_paths = [
-        splitdir(pathof(SD4SOLPS))[1] * "/../sample/",
-        splitdir(pathof(SOLPS2IMAS))[1] * "/../samples/",
+        splitdir(pathof(SD4SOLPS))[1] * "/../sample",
+        splitdir(pathof(SOLPS2IMAS))[1] * "/../samples",
     ]
     core_method = "simple"
     edge_method = "simple"


### PR DESCRIPTION
Bug fix:
- fill_in_extrapolated_core_profile! was using hard coded index for ggd quantities that was not required.
  - This was required after [SOLPS2IMAS 4ca3759](https://github.com/ProjectTorreyPines/SOLPS2IMAS.jl/commit/4ca3759c8c10d43b385c7506d837a27dbd0d16a7)
- Minor typo in heavy_utilities test for b2time file.

Hardcoded index cleanup:
- grid_ggd_idx (previously marked as ggd_idx which is confusing)
- space_idx
- eq_profiles_2d_idx
- nt is taken from length of gdd in edge_profiles
- it is iterated over instead of fixing to 1

Documentation:
- Updated docstring of fill_in_extrapolated_core_profile!
- Updated docstring of mesh_psi_spacing
- Updated docstring of core_profiles_2d
- Often used long attribute addresses are aliases to shorter names
  - grid_ggd = dd.edge_profiles.grid_ggd[grid_ggd_idx]
  - space = grid_ggd.space[space_idx]
  - eq_time_slice = dd.equilibrium.time_slice[eq_time_idx]
  - eq_prof_2d = eq_time_slice.profiles_2d[eq_profiles_2d_idx]

All tests pass on my machine as well.