### PR TITLE
Using KDTree interp for projection to midplane

### DIFF
--- a/src/supersize_profile.jl
+++ b/src/supersize_profile.jl
@@ -172,7 +172,8 @@ function fill_in_extrapolated_core_profile!(
             quantity_str,
             cell_subset,
             midplane_subset,
-            space,
+            space;
+            interp_method=:KDTree,
         )
         # Now quantity is at the outboard midplane
 


### PR DESCRIPTION
This was required as thin plate spline method for interpolation while projecting was causing a significant slowdown in each time step of fill_extrapolated_core_profile function. Now, everything is fast again.