### PR TITLE
Adding option to specify cell subset index

### DIFF
--- a/src/supersize_profile.jl
+++ b/src/supersize_profile.jl
@@ -123,6 +123,10 @@ grid_ggd_idx: index of the grid_ggd to use. For a typical SOLPS run, the SOLPS g
               is used, then this index will need to be specified.
 space_idx: index of the space to use. For a typical SOLPS run, there will be only one
            space so this index will mostly remain at 1.
+cell_subset_idx: index of the subset of cells to use for the extrapolation. The default
+                 is 5, which is the subset of all cells. If edge_profiles data is
+                 instead present for a different subset, for instance, -5, which are
+                 b2.5 cells only, then this index should be set to -5.
 """
 #!format on
 function fill_in_extrapolated_core_profile!(
@@ -133,12 +137,13 @@ function fill_in_extrapolated_core_profile!(
     eq_profiles_2d_idx::Int64=1,
     grid_ggd_idx::Int64=1,
     space_idx::Int64=1,
+    cell_subset_idx::Int64=5,
 )
     check_rho_1d(dd; time_slice=eq_time_idx, throw_on_fail=true)
     grid_ggd = dd.edge_profiles.grid_ggd[grid_ggd_idx]
     space = grid_ggd.space[space_idx]
     cell_subset =
-        get_grid_subset_with_index(grid_ggd, 5)
+        get_grid_subset_with_index(grid_ggd, cell_subset_idx)
     midplane_subset =
         get_grid_subset_with_index(grid_ggd, 11)
 


### PR DESCRIPTION
This PR should be accepted with https://github.com/ProjectTorreyPines/SOLPS2IMAS.jl/pull/30 and https://github.com/ProjectTorreyPines/SynthDiag.jl/pull/23

With SOLPS2IMAS being able to read EIRENE grid that displaces B2.5 grid to grid subset -5, the SD4SOLPS function that extrapolates B2.5 data into core using equilibrium profile should have an option of specifying the cell_subset_index. This PR provides that.

Note however, that all_cells_subset index in function pick_mesh_ext_starting_points has not been changed. It is not clear right now what we will do with this function and I propose to make changes to this function in a different PR.