### PR TITLE
Reorganization and introducing Plant as a type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SOLPS2ctrl"
 uuid = "a531d12f-ac8a-43e8-b6d9-bd121431dd49"
 authors = ["David Eldon <eldond@fusion.gat.com>"]
-version = "2.2.1"
+version = "2.2.2"
 
 [deps]
 Contour = "d38c429a-6771-53c6-b99e-75d170b6e991"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -30,7 +30,8 @@ using Pkg
 Pkg.add("SOLPS2ctrl")
 ```
 
-## Top file handling functions
+## SOLPS related functionality
+### Top file handling functions
 
 ```@docs
 find_files_in_allowed_folders
@@ -38,7 +39,7 @@ geqdsk_to_imas!
 preparation
 ```
 
-## Repairing/filling out partial equilibrium files
+### Repairing/filling out partial equilibrium files
 
 Tools for repairing/filling out partial equilibrium files.
 
@@ -51,18 +52,18 @@ add_rho_to_equilibrium!
 check_rho_1d
 ```
 
-## Extrapolations
+### Extrapolations
 
 Utilities for extrapolating profiles
 
-### Core profile extrapolations
+#### Core profile extrapolations
 
 ```@docs
 extrapolate_core
 fill_in_extrapolated_core_profile!
 ```
 
-### Edge profiles extrapolations
+#### Edge profiles extrapolations
 
 These functions have not been fully tested and/or supported yet.
 
@@ -71,17 +72,38 @@ mesh_psi_spacing
 cached_mesh_extension!
 ```
 
-## System identification and modeling
+### Unit conversion utilities
 
 ```@docs
-offset_scale
-unscale_unoffset
+gas_unit_converter
+```
+
+## Control related functionality
+
+This package provides a platform to perform closed loop simulations of controllers with
+plant models and actuator models. The key function to run these simulations is `run_closed_loop_sim()` described below. The common architecture for this platform is to create `mutable struct` for each of the actuator, plant, and controller which are
+subtypes of provided abstract types `Actuator`, `Plant`, and `Controller` and the
+struct itself is callable and performs the required function for a discrete time
+instance. See test examples to get an idea of how to use this feature.
+
+### Plant
+
+```@docs
+Plant
+LinearPlant
+InputConditioning
+InpCondLinPlant
+```
+
+### System identification and modeling
+
+```@docs
 system_id
 system_id_optimal_inp_cond
 model_evolve
 ```
 
-## Actuators
+### Actuators
 
 ```@docs
 Actuator
@@ -98,26 +120,26 @@ for (i, inp) in enumerate(inp_series)
 end
 ```
 
-## Controllers
+### Controllers
 
 ```@docs
 Controller
 ```
 
-### Linear Controller
+#### Linear Controller
 
 ```@docs
 LinearController
 ```
 
-### Predicted Variable Linear Controller
+#### Predicted Variable Linear Controller
 
 ```@docs
 PVLC
 state_prediction_matrices
 ```
 
-#### State Prediction Matrix Algebra
+##### State Prediction Matrix Algebra
 
 At step k:
 
@@ -250,22 +272,22 @@ Then, future state can be predicted by:
 x_{k+1} = \mathcal{N} \mathcal{L}^{-1} (\vec{Y} - \mathcal{M} \vec{U}) + \mathcal{O} \vec{U}
 ```
 
-### Model Predictive Controller
+#### Model Predictive Controller
 
 ```@docs
 MPC
 ```
 
-## Closed loop simulations
+### Closed loop simulations
 
 ```@docs
-lsim_step
-model_step
 run_closed_loop_sim
 ```
 
-## Unit conversion utilities
+### Control related utilities
 
 ```@docs
-gas_unit_converter
+lsim_step
+offset_scale
+unscale_unoffset
 ```

--- a/src/SOLPS2ctrl.jl
+++ b/src/SOLPS2ctrl.jl
@@ -10,7 +10,10 @@ export find_files_in_allowed_folders, geqdsk_to_imas!, preparation
 include("$(@__DIR__)/supersize_profile.jl")
 include("$(@__DIR__)/repair_eq.jl")
 include("$(@__DIR__)/unit_utils.jl")
+include("$(@__DIR__)/control_utils.jl")
+include("$(@__DIR__)/plant.jl")
 include("$(@__DIR__)/system_id.jl")
+include("$(@__DIR__)/actuators.jl")
 include("$(@__DIR__)/controllers.jl")
 
 """

--- a/src/actuators.jl
+++ b/src/actuators.jl
@@ -64,8 +64,12 @@ mutable struct DelayedActuator{U} <: Actuator
 end
 
 function (da::DelayedActuator)(inp::Union{Float64, Vector{Float64}})::Vector{Float64}
-    enqueue!(da.buffer, inp)
-    return dequeue!(da.buffer)
+    if da.delay > 0
+        enqueue!(da.buffer, inp)
+        return dequeue!(da.buffer)
+    else
+        return inp
+    end
 end
 
 function get_future_inp(act::Actuator)

--- a/src/actuators.jl
+++ b/src/actuators.jl
@@ -1,0 +1,96 @@
+import DataStructures: Queue, enqueue!, dequeue!
+
+export Actuator, DelayedActuator
+
+"""
+    Actuator
+
+Abstract parent type for all actuators. Whenever a user defined actuator is created,
+it must be subtype of `Actuator`.
+
+To create a new actuator with custom function, it must be defined as a mutable stucture
+which is daughter of Actuator that contains all settings and state information for
+the actuator and the instance itself should be callable to take as input a
+`Vector{Float64}` and should return an output of `Vector{Float64}`.
+
+```julia
+mutable struct CustomActuator <: Actuator
+    settings
+    state
+    # ... Anything more
+end
+
+function (ca::CustomActuator)(inp::Vector{Float64})::Vector{Float64}
+    # perform the actuation calcualtions with inp
+    # update ca.state if required
+    return output
+end
+```
+
+**NOTE:** If you need to add a delay in the actuator, add a [`DelayedActuator`](@ref)
+instance in the attributes of your `CustomActuator` and just call the DelayedActuator
+inside your function call.
+"""
+abstract type Actuator end
+
+"""
+    DelayedActuator{U}
+
+Implementation of delayed actuation. It stores `delay::Int` for number of time steps of
+delay and `buffer::Queue{U}` which stores the delayed actuations in a queue.
+Constructor:
+
+    DelayedActuator(
+        delay::Int;
+        default_output::T=[0.0],
+    ) where {T}
+
+Creates a DelayedActuator{T} instance with `delay` and initializes the `buffer`
+pre-filled upto brim with the default_output.
+"""
+mutable struct DelayedActuator{U} <: Actuator
+    delay::Int
+    buffer::Queue{U}
+    function DelayedActuator(
+        delay::Int;
+        default_output::T=[0.0],
+    ) where {T}
+        buffer = Queue{T}(delay)
+        for i ∈ 1:delay
+            enqueue!(buffer, default_output)
+        end
+        return new{T}(delay, buffer)
+    end
+end
+
+function (da::DelayedActuator)(inp::Union{Float64, Vector{Float64}})::Vector{Float64}
+    enqueue!(da.buffer, inp)
+    return dequeue!(da.buffer)
+end
+
+function get_future_inp(act::Actuator)
+    for fieldname ∈ fieldnames(typeof(act))
+        if fieldtype(typeof(act), fieldname) == DelayedActuator
+            return get_future_inp(getfield(act, fieldname))
+        end
+    end
+    return Matrix{Float64}(undef, 0, 0)
+end
+
+get_future_inp(act::DelayedActuator) = stack(act.buffer)
+
+function get_min_delay(act::Actuator)::Int
+    min_delay = typemax(Int)
+    has_delay = false
+    for fieldname ∈ fieldnames(typeof(act))
+        if fieldtype(typeof(act), fieldname) == DelayedActuator
+            min_delay = min(min_delay, getfield(act, fieldname).delay)
+            has_delay = true
+        end
+    end
+    if has_delay
+        return min_delay
+    else
+        return 0
+    end
+end

--- a/src/control_utils.jl
+++ b/src/control_utils.jl
@@ -1,0 +1,60 @@
+import ControlSystemIdentification: PredictionStateSpace
+import ControlSystemsBase: StateSpace
+
+export lsim_step, offset_scale, unscale_unoffset
+
+"""
+    lsim_step(
+        sys::Union{PredictionStateSpace, StateSpace}, u::Vector{Float64};
+        x0::Vector{Float64}=zeros(size(sys.A, 1)),
+    )::Tuple{Vector{Float64}, Vector{Float64}}
+
+Single step version of [ControlSystemsBase.lsim](https://juliacontrol.github.io/ControlSystems.jl/dev/lib/timefreqresponse/#ControlSystemsBase.lsim-Tuple%7BAbstractStateSpace,%20AbstractVecOrMat,%20AbstractVector%7D)
+"""
+function lsim_step(
+    sys::Union{PredictionStateSpace, StateSpace}, u::Vector{Float64};
+    x0::Vector{Float64}=zeros(size(sys.A, 1)),
+)::Tuple{Vector{Float64}, Vector{Float64}}
+    x = sys.A * x0 + sys.B * u
+    y = sys.C * x0 + sys.D * u
+    return y, x
+end
+
+"""
+    offset_scale(
+        val::Union{Float64, Vector{Float64}, Matrix{Float64}};
+        offset::Union{Float64, Vector{Float64}}=0.0,
+        factor::Union{Float64, Vector{Float64}}=1.0,
+    )::typeof(val)
+
+Subtract an `offset` and multiply by a `factor`, the `val` to make it nominally in the
+range of -1 to 1 (not strictly) for easy identification of system.
+
+    (val .- offset) .* factor
+"""
+function offset_scale(
+    val::Union{Float64, Vector{Float64}, Matrix{Float64}};
+    offset::Union{Float64, Vector{Float64}}=0.0,
+    factor::Union{Float64, Vector{Float64}}=1.0,
+)::typeof(val)
+    return (val .- offset) .* factor
+end
+
+"""
+    unscale_unoffset(
+        offset_scaled::Union{Float64, Vector{Float64}, Matrix{Float64}};
+        offset::Union{Float64, Vector{Float64}}=0.0,
+        factor::Union{Float64, Vector{Float64}}=1.0,
+    )::typeof(offset_scaled)
+
+Undo previously applied offset and scaling.
+
+    offset_scaled ./ factor .+ offset
+"""
+function unscale_unoffset(
+    offset_scaled::Union{Float64, Vector{Float64}, Matrix{Float64}};
+    offset::Union{Float64, Vector{Float64}}=0.0,
+    factor::Union{Float64, Vector{Float64}}=1.0,
+)::typeof(offset_scaled)
+    return offset_scaled ./ factor .+ offset
+end

--- a/src/controllers.jl
+++ b/src/controllers.jl
@@ -1,58 +1,66 @@
 import ControlSystemIdentification: PredictionStateSpace
 import ControlSystemsBase: StateSpace, Discrete
 import LinearAlgebra: pinv
-import DataStructures: Queue, enqueue!, dequeue!, empty!, first
+import DataStructures: Queue, enqueue!, dequeue!, empty!
 import LsqFit: curve_fit, coef
 
-export lsim_step, model_step, state_prediction_matrices, Actuator, DelayedActuator,
-    Controller, LinearController, PVLC, MPC, run_closed_loop_sim
+export Controller,
+    LinearController, PVLC, state_prediction_matrices, MPC, run_closed_loop_sim
 
 """
-    lsim_step(
-        sys::Union{PredictionStateSpace, StateSpace}, u::Vector{Float64};
-        x0::Vector{Float64}=zeros(size(sys.A, 1)),
-    )::Tuple{Vector{Float64}, Vector{Float64}}
+    Controller
 
-Single step version of [ControlSystemsBase.lsim](https://juliacontrol.github.io/ControlSystems.jl/dev/lib/timefreqresponse/#ControlSystemsBase.lsim-Tuple%7BAbstractStateSpace,%20AbstractVecOrMat,%20AbstractVector%7D)
+Abstract parent type for all controllers. Whenever a user defined controller is created
+it must be a subtype of `Controller`.
+
+To create a new controller algorithm, it should be defined as a mutable structure that
+is a daughter of `Controller` and should contain all settings and state information to
+be stored. It must be a callable structure that can use any of the following keyword
+arguments:
+
+  - `ii::Int`: Iteration index
+  - `target::Matrix{Float64}`: Target waveform (No. of signals x Time steps)
+  - `plant_inp::Matrix{Float64}`: Inputs to plant (No. of inputs x Time steps)
+  - `plant_out::Matrix{Float64}`: Outputs from plant (No. of outputs x Time steps)
+  - `act::Actuator`: Actuator model in the loop
+  - `inp_feedforward::Matrix{Float64}`: Feedforward input to the plant (No. of inputs x Time steps)
+  - `kwargs..`: Required to ignore unused keyword arguments
 """
-function lsim_step(
-    sys::Union{PredictionStateSpace, StateSpace}, u::Vector{Float64};
-    x0::Vector{Float64}=zeros(size(sys.A, 1)),
-)::Tuple{Vector{Float64}, Vector{Float64}}
-    x = sys.A * x0 + sys.B * u
-    y = sys.C * x0 + sys.D * u
-    return y, x
+abstract type Controller end
+
+"""
+    LinearController
+
+Implementation for using any linear controller. It stores
+`ctrl_ss::StateSpace{TE} where {TE <: Discrete}` for storing any linear controller as a
+discrete state space model using [ControlSystemsBase.ss](https://juliacontrol.github.io/ControlSystems.jl/dev/man/creating_systems/#State-Space-Systems).
+It also stores the state vector for the state space model as `ctrl_x0::Vector{Float64}`.
+It's call signature is:
+
+    (lc::LinearController)(;
+        ii::Int,
+        target::Matrix{Float64},
+        plant_out::Matrix{Float64},
+        kwargs...,
+    )::Vector{Float64}
+
+Calcualtes error as `target[:, ii] .- plant_out[:, ii]` and runs it through
+[`lsim_step()`](@ref).
+"""
+mutable struct LinearController <: Controller
+    ctrl_ss::StateSpace{TE} where {TE <: Discrete}
+    ctrl_x0::Vector{Float64}
 end
 
-"""
-    model_step(
-        sys::Union{PredictionStateSpace, StateSpace},
-        inp::Vector{Float64};
-        x0::Vector{Float64}=zeros(size(sys.A, 1)),
-        inp_cond::Union{Nothing, Function}=nothing,
-        inp_offset::Float64=0.0, inp_factor::Float64=1.0,
-        out_offset::Float64=0.0, out_factor::Float64=1.0,
-        inp_cond_kwargs::Dict{Symbol, T}=Dict{Symbol, Any}(),
-    )::Tuple{Vector{Float64}, Vector{Float64}} where {T}
-
-Single step version of [`model_evolve()`](@ref).
-"""
-function model_step(
-    sys::Union{PredictionStateSpace, StateSpace},
-    inp::Vector{Float64};
-    x0::Vector{Float64}=zeros(size(sys.A, 1)),
-    inp_cond::Union{Nothing, Function}=nothing,
-    inp_offset::Float64=0.0, inp_factor::Float64=1.0,
-    out_offset::Float64=0.0, out_factor::Float64=1.0,
-    inp_cond_kwargs::Dict{Symbol, T}=Dict{Symbol, Any}(),
-)::Tuple{Vector{Float64}, Vector{Float64}} where {T}
-    inp_so = offset_scale(inp; offset=inp_offset, factor=inp_factor)
-    if !isnothing(inp_cond)
-        inp_so = inp_cond(inp_so; inp_cond_kwargs...)
-    end
-    modeled_out_so, x0 = lsim_step(sys, inp_so; x0)
-    modeled_out = unscale_unoffset(modeled_out_so; offset=out_offset, factor=out_factor)
-    return modeled_out, x0
+function (lc::LinearController)(;
+    ii::Int,
+    target::Matrix{Float64},
+    plant_out::Matrix{Float64},
+    kwargs...,
+)::Vector{Float64}
+    err = target[:, ii] .- plant_out[:, ii]
+    ctrl_out, lc.ctrl_x0 = lsim_step(lc.ctrl_ss, err; x0=lc.ctrl_x0)
+    return ctrl_out
 end
 
 function _calculate_LMNO(
@@ -125,160 +133,6 @@ function state_prediction_matrices(
 end
 
 """
-    Actuator
-
-Abstract parent type for all actuators. Whenever a user defined actuator is created,
-it must be subtype of `Actuator`.
-
-To create a new actuator with custom function, it must be defined as a mutable stucture
-which is daughter of Actuator that contains all settings and state information for
-the actuator and the instance itself should be callable to take as input a
-`Vector{Float64}` and should return an output of `Vector{Float64}`.
-
-```julia
-mutable struct CustomActuator <: Actuator
-    settings
-    state
-    # ... Anything more
-end
-
-function (ca::CustomActuator)(inp::Vector{Float64})::Vector{Float64}
-    # perform the actuation calcualtions with inp
-    # update ca.state if required
-    return output
-end
-```
-
-**NOTE:** If you need to add a delay in the actuator, add a [`DelayedActuator`](@ref)
-instance in the attributes of your `CustomActuator` and just call the DelayedActuator
-inside your function call.
-"""
-abstract type Actuator end
-
-"""
-    DelayedActuator{U}
-
-Implementation of delayed actuation. It stores `delay::Int` for number of time steps of
-delay and `buffer::Queue{U}` which stores the delayed actuations in a queue.
-Constructor:
-
-    DelayedActuator(
-        delay::Int;
-        default_output::T=[0.0],
-    ) where {T}
-
-Creates a DelayedActuator{T} instance with `delay` and initializes the `buffer`
-pre-filled upto brim with the default_output.
-"""
-mutable struct DelayedActuator{U} <: Actuator
-    delay::Int
-    buffer::Queue{U}
-    function DelayedActuator(
-        delay::Int;
-        default_output::T=[0.0],
-    ) where {T}
-        buffer = Queue{T}(delay)
-        for i ∈ 1:delay
-            enqueue!(buffer, default_output)
-        end
-        return new{T}(delay, buffer)
-    end
-end
-
-function (da::DelayedActuator)(inp::Union{Float64, Vector{Float64}})::Vector{Float64}
-    enqueue!(da.buffer, inp)
-    return dequeue!(da.buffer)
-end
-
-function get_future_inp(act::Actuator)
-    for fieldname ∈ fieldnames(typeof(act))
-        if fieldtype(typeof(act), fieldname) == DelayedActuator
-            return get_future_inp(getfield(act, fieldname))
-        end
-    end
-    return Matrix{Float64}(undef, 0, 0)
-end
-
-get_future_inp(act::DelayedActuator) = stack(act.buffer)
-
-function get_min_delay(act::Actuator)::Int
-    min_delay = typemax(Int)
-    has_delay = false
-    for fieldname ∈ fieldnames(typeof(act))
-        if fieldtype(typeof(act), fieldname) == DelayedActuator
-            min_delay = min(min_delay, getfield(act, fieldname).delay)
-            has_delay = true
-        end
-    end
-    if has_delay
-        return min_delay
-    else
-        return 0
-    end
-end
-
-"""
-    Controller
-
-Abstract parent type for all controllers. Whenever a user defined controller is created
-it must be a subtype of `Controller`.
-
-To create a new controller algorithm, it should be defined as a mutable structure that
-is a daughter of `Controller` and should contain all settings and state information to
-be stored. It must be a callable structure that can use any of the following keyword
-arguments:
-
-  - `ii::Int`: Iteration index
-  - `target::Matrix{Float64}`: Target waveform (No. of signals x Time steps)
-  - `plant_inp::Matrix{Float64}`: Inputs to plant (No. of inputs x Time steps)
-  - `plant_out::Matrix{Float64}`: Outputs from plant (No. of outputs x Time steps)
-  - `act::Actuator`: Actuator model in the loop
-  - `inp_cond::Union{Nothing, Function}=nothing`: Input conditioning on plant model
-  - `inp_cond_kwargs::Dict{Symbol, Any}`: Keyword arguments for `inp_cond`
-  - `inp_offset::Float64`: Input offset for plant input
-  - `inp_factor::Float64`: Input factor for plant input
-  - `out_offset::Float64`: Output offset for plant output
-  - `out_factor::Float64`: Output factor for plant output
-  - `kwargs..`: Required to ignore unused keyword arguments
-"""
-abstract type Controller end
-
-"""
-    LinearController
-
-Implementation for using any linear controller. It stores
-`ctrl_ss::StateSpace{TE} where {TE <: Discrete}` for storing any linear controller as a
-discrete state space model using [ControlSystemsBase.ss](https://juliacontrol.github.io/ControlSystems.jl/dev/man/creating_systems/#State-Space-Systems).
-It also stores the state vector for the state space model as `ctrl_x0::Vector{Float64}`.
-It's call signature is:
-
-    (lc::LinearController)(;
-        ii::Int,
-        target::Matrix{Float64},
-        plant_out::Matrix{Float64},
-        kwargs...,
-    )::Vector{Float64}
-
-Calcualtes error as `target[:, ii] .- plant_out[:, ii]` and runs it through
-[`lsim_step()`](@ref).
-"""
-mutable struct LinearController <: Controller
-    ctrl_ss::StateSpace{TE} where {TE <: Discrete}
-    ctrl_x0::Vector{Float64}
-end
-
-function (lc::LinearController)(;
-    ii::Int,
-    target::Matrix{Float64},
-    plant_out::Matrix{Float64},
-    kwargs...,
-)::Vector{Float64}
-    err = target[:, ii] .- plant_out[:, ii]
-    ctrl_out, lc.ctrl_x0 = lsim_step(lc.ctrl_ss, err; x0=lc.ctrl_x0)
-    return ctrl_out
-end
-
-"""
     PVLC
 
 Implementation of Predicted Variable Linear Controller (PVLC). It stores
@@ -293,7 +147,7 @@ There is a convinience contructor:
     PVLC(
         ctrl_ss::StateSpace{TE},
         ctrl_x0::Vector{Float64},
-        plant::Union{PredictionStateSpace, StateSpace},
+        plant::Plant,
         h::Int,
     ) where {TE <: Discrete}
 
@@ -305,8 +159,6 @@ This controller has a call signature:
         plant_inp::Matrix{Float64},
         plant_out::Matrix{Float64},
         act::Actuator,
-        inp_offset::Float64=0.0, inp_factor::Float64=1.0,
-        out_offset::Float64=0.0, out_factor::Float64=1.0,
         kwargs...,
     )::Vector{Float64}
 
@@ -317,17 +169,17 @@ future `target` value and applies the linear controller `ctrl_ss` there.
 mutable struct PVLC <: Controller
     ctrl_ss::StateSpace{TE} where {TE <: Discrete}
     ctrl_x0::Vector{Float64}
-    plant::Union{PredictionStateSpace, StateSpace}
+    plant::Plant
     h::Int
     Y2x::Matrix{Float64}
     U2x::Matrix{Float64}
     function PVLC(
         ctrl_ss::StateSpace{TE},
         ctrl_x0::Vector{Float64},
-        plant::Union{PredictionStateSpace, StateSpace},
+        plant::Plant,
         h::Int,
     ) where {TE <: Discrete}
-        Y2x, U2x = state_prediction_matrices(plant, h)
+        Y2x, U2x = state_prediction_matrices(get_sys(plant), h)
         return new(ctrl_ss, ctrl_x0, plant, h, Y2x, U2x)
     end
 end
@@ -338,8 +190,6 @@ function (pvlc::PVLC)(;
     plant_inp::Matrix{Float64},
     plant_out::Matrix{Float64},
     act::Actuator,
-    inp_offset::Float64=0.0, inp_factor::Float64=1.0,
-    out_offset::Float64=0.0, out_factor::Float64=1.0,
     kwargs...,
 )::Vector{Float64}
     ctrl_out = zeros(Float64, size(pvlc.ctrl_ss.C, 1))
@@ -350,13 +200,9 @@ function (pvlc::PVLC)(;
         U = vec(plant_inp[:, (ii-pvlc.h+1):ii])
         Y = vec(plant_out[:, (ii-pvlc.h+1):ii])
         # Estimate current state vector of plant model
-        est_x = pvlc.Y2x * Y .+ pvlc.U2x * U
+        set_x!(pvlc.plant, pvlc.Y2x * Y .+ pvlc.U2x * U)
         # Evolve into the future for the delay in actuator
-        future_out = model_evolve(
-            pvlc.plant, future_inp;
-            x0=est_x,
-            inp_offset, inp_factor, out_offset, out_factor,
-        )
+        future_out = model_evolve(pvlc.plant, future_inp)
         # Estimate the error signal in future
         err = target[:, ii+lat] - future_out[:, end]
         # Apply the linear controller in future
@@ -402,7 +248,7 @@ it can reuse it's previous optimization results.
 There is a convinience contructor:
 
     MPC(
-        plant::Union{PredictionStateSpace, StateSpace},
+        plant::Plant,
         h::Int,
         act::Actuator,               # Actuator model without delay
         horizon::Int,                # Number of steps in future after latency
@@ -427,19 +273,15 @@ over-calculations and thus results in a faster controller.
 
 This controller has a call signature:
 
-    (mpc::MPC)(;
+    function (mpc::MPC)(;
         ii::Int,
         target::Matrix{Float64},
         plant_inp::Matrix{Float64},
         plant_out::Matrix{Float64},
         act::Actuator,
-        inp_cond::Union{Nothing, Function}=nothing,
-        inp_offset::Float64=0.0, inp_factor::Float64=1.0,
-        out_offset::Float64=0.0, out_factor::Float64=1.0,
-        inp_cond_kwargs::Dict{Symbol, T}=Dict{Symbol, Any}(),
         inp_feedforward::Matrix{Float64}=zeros(
             Float64,
-            (size(plant.B, 2), length(target)),
+            (size(get_sys(plant).B, 2), length(target)),
         ),
         kwargs...,
     )::Vector{Float64} where {T}
@@ -453,7 +295,7 @@ function performs the optimization every `opt_every` call and uses the stored co
 output in `ctrl_out_buffer` meanwhile.
 """
 mutable struct MPC <: Controller
-    plant::Union{PredictionStateSpace, StateSpace}
+    plant::Plant
     h::Int
     Y2x::Matrix{Float64}
     U2x::Matrix{Float64}
@@ -467,7 +309,7 @@ mutable struct MPC <: Controller
     future_evolve::Function
     ctrl_out_buffer::Queue{Vector{Float64}}
     function MPC(
-        plant::Union{PredictionStateSpace, StateSpace},
+        plant::Plant,
         h::Int,
         act::Actuator,               # Actuator model without delay
         horizon::Int,                # Number of steps in future after latency
@@ -478,25 +320,20 @@ mutable struct MPC <: Controller
             Array{Float64}(undef, 0),
         ),
     )
-        Y2x, U2x = state_prediction_matrices(plant, h)
+        Y2x, U2x = state_prediction_matrices(get_sys(plant), h)
         min_delay = get_min_delay(act)
         function fe(
             red_steps::StepRange{Int, Int}, red_ctrl_out::Vector{Float64};
             mpc::MPC,
             inp_ff::Matrix{Float64}=zeros(
                 Float64,
-                size(mpc.plant.B, 2),
+                size(get_sys(mpc.plant).B, 2),
                 min_delay + horizon + 1,
             ),
-            x0::Vector{Float64}=zeros(Float64, size(mpc.plant.A, 2)),
-            inp_cond::Union{Nothing, Function}=nothing,
-            inp_offset::Float64=0.0, inp_factor::Float64=1.0,
-            out_offset::Float64=0.0, out_factor::Float64=1.0,
-            inp_cond_kwargs::Dict{Symbol, T}=Dict{Symbol, Any}(),
-        ) where {T}
+        )
             act = deepcopy(mpc.act)
-            ninps = size(mpc.plant.B, 2)
-            nouts = size(mpc.plant.C, 1)
+            ninps = size(get_sys(mpc.plant).B, 2)
+            nouts = size(get_sys(mpc.plant), 1)
             ctrl_out = expand(red_steps, red_ctrl_out, ninps, mpc.horizon)
             # Padding far in future extra zero inputs, these won't make any effect
             # because of the minium delay
@@ -505,12 +342,7 @@ mutable struct MPC <: Controller
             plant_out = zeros(Float64, nouts, mpc.min_delay + mpc.horizon + 1)
             for i ∈ 1:(mpc.min_delay+mpc.horizon+1)
                 plant_inp = act(ctrl_out[i] .+ inp_ff[:, i])
-                plant_out[:, i], x0 = model_step(
-                    mpc.plant, plant_inp;
-                    x0,
-                    inp_cond, inp_offset, inp_factor, out_offset, out_factor,
-                    inp_cond_kwargs,
-                )
+                plant_out[:, i] = mpc.plant(plant_inp)
             end
             return vec(plant_out)
         end
@@ -529,16 +361,12 @@ function (mpc::MPC)(;
     plant_inp::Matrix{Float64},
     plant_out::Matrix{Float64},
     act::Actuator,
-    inp_cond::Union{Nothing, Function}=nothing,
-    inp_offset::Float64=0.0, inp_factor::Float64=1.0,
-    out_offset::Float64=0.0, out_factor::Float64=1.0,
-    inp_cond_kwargs::Dict{Symbol, T}=Dict{Symbol, Any}(),
     inp_feedforward::Matrix{Float64}=zeros(
         Float64,
-        (size(plant.B, 2), length(target)),
+        (size(get_sys(plant).B, 2), length(target)),
     ),
     kwargs...,
-)::Vector{Float64} where {T}
+)::Vector{Float64}
     fut_lookup = mpc.min_delay + mpc.horizon + 1
 
     enough_history = ii - mpc.h + 1 > 0
@@ -550,13 +378,13 @@ function (mpc::MPC)(;
         red_steps = 1:div(mpc.horizon, mpc.nopt-1):(mpc.horizon+1)
         lower = repeat(mpc.ctrl_out_bounds[1], length(red_steps))
         upper = repeat(mpc.ctrl_out_bounds[2], length(red_steps))
-        ninps = size(mpc.plant.B, 2)
+        ninps = size(get_sys(mpc.plant).B, 2)
 
         # Gather history of inputs and outputs
         U = vec(plant_inp[:, (ii-mpc.h+1):ii])
         Y = vec(plant_out[:, (ii-mpc.h+1):ii])
         # Estimate current state vector of plant model
-        x0 = mpc.Y2x * Y .+ mpc.U2x * U
+        set_x!(mpc.plant, mpc.Y2x * Y .+ mpc.U2x * U)
 
         # Prepare arguments for cost optimization
         mpc.act = deepcopy(act)
@@ -566,11 +394,7 @@ function (mpc::MPC)(;
 
         # Optimize
         fit_res = curve_fit(
-            (x, y) -> mpc.future_evolve(
-                x, y; mpc, inp_ff, x0,
-                inp_cond, inp_offset, inp_factor, out_offset, out_factor,
-                inp_cond_kwargs,
-            ),
+            (x, y) -> mpc.future_evolve(x, y; mpc, inp_ff),
             red_steps, target_vec, guess;
             lower, upper,
         )
@@ -585,7 +409,7 @@ function (mpc::MPC)(;
         mpc.last_opt = ii
     end
     if isempty(mpc.ctrl_out_buffer)
-        return zeros(Float64, size(mpc.plant.B, 2))
+        return zeros(Float64, size(get_sys(mpc.plant).B, 2))
     else
         return dequeue!(mpc.ctrl_out_buffer)
     end
@@ -597,26 +421,22 @@ end
         act::Actuator,
         ctrl::Controller,
         target::Matrix{Float64};
-        inp_cond::Union{Nothing, Function}=nothing,
-        inp_offset::Float64=0.0, inp_factor::Float64=1.0,
-        out_offset::Float64=0.0, out_factor::Float64=1.0,
-        inp_cond_kwargs::Dict{Symbol, T}=Dict{Symbol, Any}(),
         inp_feedforward::Matrix{Float64}=zeros(
             Float64,
-            (size(plant.B, 2), size(target, 2)),
+            (size(get_sys(plant).B, 2), size(target, 2)),
         ),
         ctrl_start_ind::Int=1,
         noise_plant_inp::Matrix{Float64}=zeros(
             Float64,
-            (size(plant.B, 2), size(target, 2)),
+            (size(get_sys(plant).B, 2), size(target, 2)),
         ),
         noise_plant_out::Matrix{Float64}=zeros(
             Float64,
-            (size(plant.C, 1), size(target, 2)),
+            (size(get_sys(plant).C, 1), size(target, 2)),
         ),
         noise_ctrl_out::Matrix{Float64}=zeros(
             Float64,
-            (size(plant.B, 2), size(target, 2)),
+            (size(get_sys(plant).B, 2), size(target, 2)),
         ),
     ) where {T, TE <: Discrete}
 
@@ -630,63 +450,51 @@ and `noise_ctrl_out` allow addition of predefined noise waveforms at the input o
 output of plant, and the output of controller respectively.
 """
 function run_closed_loop_sim(
-    plant::Union{PredictionStateSpace{TE}, StateSpace{TE}},
+    plant::Plant,
     act::Actuator,
     ctrl::Controller,
     target::Matrix{Float64};
-    inp_cond::Union{Nothing, Function}=nothing,
-    inp_offset::Float64=0.0, inp_factor::Float64=1.0,
-    out_offset::Float64=0.0, out_factor::Float64=1.0,
-    inp_cond_kwargs::Dict{Symbol, T}=Dict{Symbol, Any}(),
     inp_feedforward::Matrix{Float64}=zeros(
         Float64,
-        (size(plant.B, 2), size(target, 2)),
+        (size(get_sys(plant).B, 2), size(target, 2)),
     ),
     ctrl_start_ind::Int=1,
     noise_plant_inp::Matrix{Float64}=zeros(
         Float64,
-        (size(plant.B, 2), size(target, 2)),
+        (size(get_sys(plant).B, 2), size(target, 2)),
     ),
     noise_plant_out::Matrix{Float64}=zeros(
         Float64,
-        (size(plant.C, 1), size(target, 2)),
+        (size(get_sys(plant).C, 1), size(target, 2)),
     ),
     noise_ctrl_out::Matrix{Float64}=zeros(
         Float64,
-        (size(plant.B, 2), size(target, 2)),
+        (size(get_sys(plant).B, 2), size(target, 2)),
     ),
-) where {T, TE <: Discrete}
+)
     # Initialization
     ctrl_out = zeros(Float64, size(inp_feedforward))
-    plant_inp = zeros(Float64, (size(plant.B, 2), length(target)))
-    plant_out = zeros(Float64, (size(plant.C, 1), length(target)))
-    x0 =
-        inv(Matrix{Float64}(I, size(plant.A)...) - plant.A) *
-        plant.B * inp_feedforward[:, 1]
+    plant_sys = get_sys(plant)
+    plant_inp = zeros(Float64, (size(plant_sys.B, 2), length(target)))
+    plant_out = zeros(Float64, (size(plant_sys.C, 1), length(target)))
+    get_x(plant) =
+        inv(Matrix{Float64}(I, size(plant_sys.A)...) - plant_sys.A) *
+        plant_sys.B * inp_feedforward[:, 1]
 
     # Closed loop simulation
-    for ii ∈ eachindex(target)
+    for ii ∈ axes(target, 2)
         # Actuation
         plant_inp[:, ii] =
             act(ctrl_out[:, ii] .+ inp_feedforward[:, ii]) .+ noise_plant_inp[:, ii]
 
         # Plant response
-        plant_out[:, ii], x0 = model_step(
-            plant, plant_inp[:, ii];
-            x0,
-            inp_cond, inp_offset, inp_factor, out_offset, out_factor,
-            inp_cond_kwargs,
-        )
+        plant_out[:, ii] = plant(plant_inp[:, ii])
         plant_out[:, ii] .+= noise_plant_out[:, ii]
-        # future_inp = get_future_inp(act)
 
         # Controller
         if ii >= ctrl_start_ind && ii < length(target)
             ctrl_out[:, ii+1] =
-                ctrl(;
-                    ii, target, plant_inp, plant_out, act, inp_feedforward,
-                    inp_cond, inp_cond_kwargs,
-                    inp_offset, inp_factor, out_offset, out_factor,
+                ctrl(; ii, target, plant_inp, plant_out, act, inp_feedforward
                 ) .+ noise_ctrl_out[:, ii+1]
         end
     end
@@ -695,12 +503,6 @@ function run_closed_loop_sim(
         :act => act,
         :ctrl => ctrl,
         :target => target,
-        :inp_cond => inp_cond,
-        :inp_offset => inp_offset,
-        :inp_factor => inp_factor,
-        :out_offset => out_offset,
-        :out_factor => out_factor,
-        :inp_cond_kwargs => inp_cond_kwargs,
         :inp_feedforward => inp_feedforward,
         :ctrl_start_ind => ctrl_start_ind,
         :plant_inp => plant_inp,

--- a/src/plant.jl
+++ b/src/plant.jl
@@ -1,0 +1,159 @@
+import ControlSystemIdentification: PredictionStateSpace
+import ControlSystemsBase: StateSpace
+
+export Plant,
+    LinearPlant, InputConditioning, InpCondLinPlant, get_linear_plant, get_sys, get_x,
+    set_x!
+
+"""
+    Plant
+
+Abstract parent type for all plants. Whenever a user defined plant is created,
+it must be subtype of `Plant`.
+
+To create a new plant with custom feautres, it must be defined as a mutable stucture
+which is daughter of `Plant` that contains all settings and state information for
+the plant and the instance itself should be callable to take as input a
+`Vector{Float64}` and should return an output of `Vector{Float64}`.
+
+```julia
+mutable struct CustomPlant <: Plant
+    settings
+    state
+    # ... Anything more
+end
+
+function (cp::CustomPlant)(inp::Vector{Float64})::Vector{Float64}
+    # perform the plant single step forward calcualtion with inp
+    # update cp.state if required
+    return output
+end
+```
+
+**NOTE:** If you need to add a linear system in your plant model, add a
+[`LinearPlant`](@ref) instance in the attributes of your `CustomPlant` and just call
+the LinearPlant inside your function call.
+"""
+abstract type Plant end
+
+"""
+    LinearPlant
+
+Implementation of linear system with option of scaling and offseting inputs and outputs.
+It stores the system in `sys` and state of the system in `x`.
+Constructor:
+
+    LinearPlant(
+        sys::Union{PredictionStateSpace, StateSpace},
+        x=zeros(Float64, size(sys.A, 1));
+        inp_offset::Float64=0.0, inp_factor::Float64=1.0,
+        out_offset::Float64=0.0, out_factor::Float64=1.0,
+    )
+
+Creates a LinearPlant instance with state space system `sys` and state vector `x`. It
+also defined input offsetting and scaling with  `inp_offset` and `inp_factor`, and
+similarly output unscaling and unoffseting with `out_offset` and `out_factor`.
+"""
+mutable struct LinearPlant <: Plant
+    sys::Union{PredictionStateSpace, StateSpace}
+    x::Vector{Float64}
+    inp_offset::Float64
+    inp_factor::Float64
+    out_offset::Float64
+    out_factor::Float64
+    function LinearPlant(
+        sys::Union{PredictionStateSpace, StateSpace},
+        x=zeros(Float64, size(sys.A, 1));
+        inp_offset::Float64=0.0, inp_factor::Float64=1.0,
+        out_offset::Float64=0.0, out_factor::Float64=1.0,
+    )
+        return new(sys, x, inp_offset, inp_factor, out_offset, out_factor)
+    end
+end
+
+function (lp::LinearPlant)(inp::Vector{Float64})::Vector{Float64}
+    u = offset_scale(inp; offset=lp.inp_offset, factor=lp.inp_factor)
+    modeled_out_so, lp.x = lsim_step(lp.sys, u; x0=lp.x)
+    return unscale_unoffset(modeled_out_so; offset=lp.out_offset, factor=lp.out_factor)
+end
+
+"""
+    InputConditioning
+
+Abstract parent type for creating input conditioning to plants. Whenever a user
+defined input coniditioning is created it must be subtype of `InputConditioning`.
+
+To create a new input conditioning with custom feautres, it must be defined as a
+mutable stucture which is daughter of `InputConditioning` that contains all settings
+and state information for the function and the instance itself should be callable to
+take as input a `Vector{Float64}` and kwargs for any parameters used and should return
+an output of `Vector{Float64}` which is same size as the input.
+
+```julia
+mutable struct CustomInpCond <: InputConditioning
+    settings
+    state
+    # ... Anything more
+end
+
+function (inp_cond::CustomInpCond)(inp::Vector{Float64}; kwargs...)::Vector{Float64}
+    # perform the input coniditioning single step forward calcualtion with inp
+    # Use parameters from kwargs
+    # update inp_cond.state if required
+    return output
+end
+```
+
+Note that `inp_cond` must have a call signature
+of `inp_cond(inp::Vector{Float64}; kwargs...)::Vector{Float64}` to take input as a
+vector for multiple inputs at a particular time instance
+"""
+abstract type InputConditioning end
+
+"""
+    InpCondLinPlant
+
+Implementation of a LinearPlant with an added input conditioning which could be used to
+make it non-linear.
+It stores the LinearPlant in `linear_plant`, the input coniditioning function in
+`inp_cond` and any keyword arguments for the `inp_cond` in `inp_cond_kwargs`.
+Constructor:
+
+    InpCondLinPlant{T}(
+        linear_plant::LinearPlant,
+        inp_cond::InputConditioning
+        inp_cond_kwargs::Dict{Symbol, T}
+    ) where {T}
+
+Creates a InpCondLinPlant instance. `inp_cond_kwargs` can be used to have changeable
+parameters in the input conditioning which can be used for optimization and fiting.
+"""
+mutable struct InpCondLinPlant{T} <: Plant
+    linear_plant::LinearPlant
+    inp_cond::InputConditioning
+    inp_cond_kwargs::Dict{Symbol, T}
+end
+
+function (nlp::InpCondLinPlant)(inp::Vector{Float64})::Vector{Float64}
+    conditioned_inp = nlp.inp_cond(inp; nlp.inp_cond_kwargs...)
+    return nlp.linear_plant(conditioned_inp)
+end
+
+function get_linear_plant(p::Plant)
+    for fieldname ∈ fieldnames(typeof(p))
+        if fieldtype(typeof(p), fieldname) == LinearPlant
+            return getfield(p, fieldname)
+        end
+    end
+    return error(
+        "Plant must use an attribute of type LinearPlant to store the linear plant model",
+    )
+end
+
+get_linear_plant(p::LinearPlant) = p
+
+get_sys(p::Plant) = get_linear_plant(p).sys
+
+get_x(p::Plant) = get_linear_plant(p).x
+
+set_x!(p::Plant, x::Vector{Float64}) = setfield!(get_linear_plant(p), :x, x)


### PR DESCRIPTION
Releasing v2.2.2

Plant is now an Abstract Type just like Actuators and Controllers. It
will also be callable and should hold any input conditioning inside it.

The InputConditioning is provided as an Abstract Type also and now
system_id and system_id_optimal_inp_cond both return a Plant object
directly.

PVLC and MPC have been updated.